### PR TITLE
change embeddings to array

### DIFF
--- a/nlp_assignment/nlp_assignment.ipynb
+++ b/nlp_assignment/nlp_assignment.ipynb
@@ -77,6 +77,7 @@
     "import matplotlib.pylab as plt\n",
     "\n",
     "# numpy\n",
+    "import numpy as np\n",
     "from numpy.testing import assert_almost_equal\n",
     "from numpy.linalg import norm\n",
     "\n",
@@ -653,7 +654,7 @@
     "embeddings = [w2v_small[word] for word in words]\n",
     "\n",
     "# perform T-SNE\n",
-    "words_embedded = TSNE(n_components=2).fit_transform(embeddings)\n",
+    "words_embedded = TSNE(n_components=2).fit_transform(np.array(embeddings))\n",
     "\n",
     "# ... and visualize!\n",
     "plt.figure(figsize=(20, 20))\n",
@@ -1721,13 +1722,6 @@
     "\n",
     "    "
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -1755,7 +1749,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This previously embeddings was a list of vectors, which now causes a problem when fitting the TSNE.  Changed to convert it to a numpy array.